### PR TITLE
Fixed deprecated after_destroy for Rails 3

### DIFF
--- a/lib/tagging.rb
+++ b/lib/tagging.rb
@@ -2,7 +2,11 @@ class Tagging < ActiveRecord::Base #:nodoc:
   belongs_to :tag
   belongs_to :taggable, :polymorphic => true
   
-  def after_destroy
+  after_destroy :destroy_tag_if_unused
+  
+  private
+  
+  def destroy_tag_if_unused
     if Tag.destroy_unused
       if tag.taggings.count.zero?
         tag.destroy


### PR DESCRIPTION
This fixes issue #8 for Rails 3
