### PR TITLE
Use Gemfile for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.bundle
+test/*.log

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+gem 'activerecord', '~>2.3.9'
+gem 'actionpack', '~>2.3.9'
+gem 'activesupport', '~>2.3.9'
+
+gem 'rake'
+gem 'sqlite3-ruby', :require => 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  specs:
+    actionpack (2.3.9)
+      activesupport (= 2.3.9)
+      rack (~> 1.1.0)
+    activerecord (2.3.9)
+      activesupport (= 2.3.9)
+    activesupport (2.3.9)
+    rack (1.1.0)
+    rake (0.8.7)
+    sqlite3-ruby (1.3.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  actionpack (~> 2.3.9)
+  activerecord (~> 2.3.9)
+  activesupport (~> 2.3.9)
+  rake
+  sqlite3-ruby

--- a/Gemfile.rails3
+++ b/Gemfile.rails3
@@ -1,0 +1,6 @@
+gem 'activerecord', '~>3.0.0'
+gem 'actionpack', '~>3.0.0'
+gem 'activesupport', '~>3.0.0'
+
+gem 'rake'
+gem 'sqlite3-ruby', :require => 'sqlite3'

--- a/Gemfile.rails3.lock
+++ b/Gemfile.rails3.lock
@@ -1,0 +1,47 @@
+GEM
+  specs:
+    abstract (1.0.0)
+    actionpack (3.0.0)
+      activemodel (= 3.0.0)
+      activesupport (= 3.0.0)
+      builder (~> 2.1.2)
+      erubis (~> 2.6.6)
+      i18n (~> 0.4.1)
+      rack (~> 1.2.1)
+      rack-mount (~> 0.6.12)
+      rack-test (~> 0.5.4)
+      tzinfo (~> 0.3.23)
+    activemodel (3.0.0)
+      activesupport (= 3.0.0)
+      builder (~> 2.1.2)
+      i18n (~> 0.4.1)
+    activerecord (3.0.0)
+      activemodel (= 3.0.0)
+      activesupport (= 3.0.0)
+      arel (~> 1.0.0)
+      tzinfo (~> 0.3.23)
+    activesupport (3.0.0)
+    arel (1.0.1)
+      activesupport (~> 3.0.0)
+    builder (2.1.2)
+    erubis (2.6.6)
+      abstract (>= 1.0.0)
+    i18n (0.4.1)
+    rack (1.2.1)
+    rack-mount (0.6.13)
+      rack (>= 1.0.0)
+    rack-test (0.5.4)
+      rack (>= 1.0)
+    rake (0.8.7)
+    sqlite3-ruby (1.3.1)
+    tzinfo (0.3.23)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  actionpack (~> 3.0.0)
+  activerecord (~> 3.0.0)
+  activesupport (~> 3.0.0)
+  rake
+  sqlite3-ruby

--- a/lib/acts_as_taggable.rb
+++ b/lib/acts_as_taggable.rb
@@ -147,8 +147,8 @@ module ActiveRecord #:nodoc:
           conditions = conditions.join(" AND ")
           
           joins = ["INNER JOIN #{table_name} ON #{table_name}.#{primary_key} = #{Tagging.table_name}.taggable_id"]
-          joins << options.delete(:joins) if options[:joins]
-          joins << scope[:joins] if scope && scope[:joins]
+          joins << options.delete(:joins) if options[:joins].present?
+          joins << scope[:joins] if scope && scope[:joins].present?
           joins = joins.join(" ")
           
           options = { :conditions => conditions, :joins => joins }.update(options)

--- a/test/abstract_unit.rb
+++ b/test/abstract_unit.rb
@@ -3,16 +3,14 @@ require 'test/unit'
 begin
   require File.dirname(__FILE__) + '/../../../../config/environment'
 rescue LoadError
-  require 'rubygems'
-  gem 'activerecord'
-  gem 'actionpack'
   require 'active_record'
   require 'action_controller'
+  require 'active_support/dependencies'
 end
 
 # Search for fixtures first
 fixture_path = File.dirname(__FILE__) + '/fixtures/'
-ActiveSupport::Dependencies.load_paths.insert(0, fixture_path)
+ActiveSupport::Dependencies.autoload_paths.insert(0, fixture_path)
 
 require "active_record/test_case"
 require "active_record/fixtures"


### PR DESCRIPTION
Did this to avoid dependency issues when switching between rails 2.3.x and 3.0.0 for testing
- run "bundle install" to initialize your .bundle directory
- run tests: "DB='sqlite3' bundle exec rake"

Currently 2 tests fail on rails 2.3.9, yonkeltron and I are looking into it.  Most of the tests fail on Rails 3 with errors similar to the issue from my previous pull request.  If I have time I'll look at those this weekend.
